### PR TITLE
Fix Tindeq Scan

### DIFF
--- a/hooks/useTindeq.ts
+++ b/hooks/useTindeq.ts
@@ -121,6 +121,7 @@ export const useTindeq = () => {
         return;
       }
 
+      if (scannedDevice?.name?.startsWith("Progressor")) {
         bleManager.stopDeviceScan();
         connect(scannedDevice.id);
       }

--- a/hooks/useTindeq.ts
+++ b/hooks/useTindeq.ts
@@ -121,7 +121,6 @@ export const useTindeq = () => {
         return;
       }
 
-      if (scannedDevice?.name === "Progressor_2068") {
         bleManager.stopDeviceScan();
         connect(scannedDevice.id);
       }


### PR DESCRIPTION
Fixes the Tindeq scan as it was previously hard coded to a single model.

This ensures every model will be picked up.